### PR TITLE
feat: Support O_DIRECT by flushing after every write.

### DIFF
--- a/go-storage-fio-engine.c
+++ b/go-storage-fio-engine.c
@@ -54,7 +54,7 @@ int go_storage_open_file(struct thread_data* td, struct fio_file* f) {
   GoUintptr completions = (GoUintptr)td->io_ops_data;
   GoUintptr go_file = 0;
   if (td_rw(td)) {
-    printf("Go Storage only supports readonly and writeonly files");
+    printf("Go Storage only supports readonly and writeonly files\n");
     return EINVAL;
   }
   if (td_read(td)) {
@@ -62,7 +62,7 @@ int go_storage_open_file(struct thread_data* td, struct fio_file* f) {
   }
   if (td->o.td_ddir == TD_DDIR_WRITE) {
     // We only support sequential, non-trimming writes.
-    go_file = GoStorageOpenWriteonly(completions, f->file_name);
+    go_file = GoStorageOpenWriteonly(completions, td->o.odirect, f->file_name);
   }
 
   if (go_file == 0) {

--- a/storagewrapper/storagewrapper.go
+++ b/storagewrapper/storagewrapper.go
@@ -62,7 +62,8 @@ type mrdFile struct {
 }
 
 type writerFile struct {
-	w *storage.Writer
+	w                    *storage.Writer
+	flushAfterEveryWrite bool
 }
 
 type goFile interface {
@@ -195,7 +196,7 @@ func GoStorageOpenReadonly(td uintptr, file_name_cstr *C.char) uintptr {
 }
 
 //export GoStorageOpenWriteonly
-func GoStorageOpenWriteonly(td uintptr, file_name_cstr *C.char) uintptr {
+func GoStorageOpenWriteonly(td uintptr, flush_after_every_write bool, file_name_cstr *C.char) uintptr {
 	file_name := C.GoString(file_name_cstr)
 	slog.Debug("go storage open writeonly", "td", td, "file_name", file_name)
 	bucket, object, ok := strings.Cut(file_name, "/")
@@ -214,7 +215,7 @@ func GoStorageOpenWriteonly(td uintptr, file_name_cstr *C.char) uintptr {
 	w := oh.NewWriter(context.Background())
 	w.Append = true
 	w.FinalizeOnClose = true
-	return uintptr(cgo.NewHandle(&writerFile{w}))
+	return uintptr(cgo.NewHandle(&writerFile{w, flush_after_every_write}))
 }
 
 //export GoStorageClose
@@ -263,6 +264,12 @@ func (w *writerFile) enqueue(p []byte, offset int64, tag unsafe.Pointer) int {
 	if _, err := w.w.Write(p); err != nil {
 		slog.Error("write error", "error", err)
 		return -1
+	}
+	if w.flushAfterEveryWrite {
+		if _, err := w.w.Flush(); err != nil {
+			slog.Error("flush error", "error", err)
+			return -1
+		}
 	}
 	return fioQCompleted
 }


### PR DESCRIPTION
O_DIRECT is implicit for reads (buffered reads aren't possible) but we _do_ buffer writes by default. Support O_DIRECT in the write path by explicitly flushing after each write call.