### PR TITLE
fix: Create serially when all workers use one file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ bazel-bin/external/_main~_repo_rules~fio_repo/fio_build/bin/fio \
   --rw=randread \
   --ioengine=external:bazel-bin/libgo-storage-fio-engine.so \
   --thread \
-  --create_serialize=0 \
+  --create_serialize=1 \
   --clat_percentiles=0 \
   --lat_percentiles=1 \
   --group_reporting=1 \


### PR DESCRIPTION
The existing instructions would have multiple workers create the file concurrently if it didn't already exist. Each overwrite would be reported as a takeover to the prior writer. The last writer would win, but lots of errors would be reported.