### PR TITLE
feat: Add integration tests.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 
+exports_files(["testbench_helper.sh"])
+
 cc_library(
     name = "ioengine",
     srcs = [
@@ -42,4 +44,27 @@ sh_test(
         ":ioengine_shared",
         "@fio_repo//:fio",
     ],
+)
+
+sh_test(
+    name = "fio_integration_test",
+    srcs = ["run_fio_integration_tests.sh"],
+    args = [
+        "$(location @fio_repo//:fio)",
+        "$(location :ioengine_shared)",
+        "$(location :testbench_helper.sh)",
+        "$(location :fio_validator.py)",
+        "$(location @storage_testbench//:setup.py)",
+        "$(location @storage_testbench//:testbench_run.py)",
+    ],
+    data = [
+        "@fio_repo//:fio",
+        ":ioengine_shared",
+        ":testbench_helper.sh",
+        ":fio_validator.py",
+        "@storage_testbench//:all_files",
+        "@storage_testbench//:setup.py",
+        "@storage_testbench//:testbench_run.py",
+    ],
+    tags = ["local"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ bazel_dep(name = "rules_go", version = "0.60.0")
 
 # Use local make toolchain instead of building it from scratch.
 register_toolchains("@rules_foreign_cc//toolchains:preinstalled_make_toolchain")
+
 # We don't use pkgconfig, so use the local one instead of building it from
 # scratch.
 register_toolchains("@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain")
@@ -30,3 +31,19 @@ go_sdk.from_file(go_mod = "//storagewrapper:go.mod")
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//storagewrapper:go.mod")
 use_repo(go_deps, "com_google_cloud_go_storage", "org_golang_google_api", "org_golang_google_grpc")
+
+http_archive(
+    name = "storage_testbench",
+    build_file_content = """
+exports_files(["setup.py", "testbench_run.py"])
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+""",
+    sha256 = "152fdb7f55005dbd2a79bde4518b0644501d906170d30094515e645241352262",
+    strip_prefix = "storage-testbench-0.62.0",
+    urls = ["https://github.com/googleapis/storage-testbench/archive/refs/tags/v0.62.0.tar.gz"],
+    dev_dependency = True,
+)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ storage class.
 
 ## Quickstart
 
-Install `make` and a C/C++ compiler, e.g. via the `build-essential` package, and
-[go](https://go.dev/).
+Install `python3`, `make` and a C/C++ compiler, e.g. via the `build-essential`
+package, and [go](https://go.dev/).
 
 Then, install [bazelisk](https://github.com/bazelbuild/bazelisk):
 
@@ -264,3 +264,13 @@ not supported.
 Prepopulation cannot be cancelled with SIGINT/Ctrl-C.
 
 `fio` may hang if an error occurs at read high iodepth.
+
+## Development
+
+This repo contains a small integration test suite using the GCS
+[storage\_testbench](https://github.com/googleapis/storage-testbench). Run it
+with:
+
+```bash
+"$(go env GOPATH)/bin/bazelisk" test //...
+```

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Prepopulation cannot be cancelled with SIGINT/Ctrl-C.
 ## Development
 
 This repo contains a small integration test suite using the GCS
-[storage\_testbench](https://github.com/googleapis/storage-testbench). Run it
+[storage-testbench](https://github.com/googleapis/storage-testbench). Run it
 with:
 
 ```bash

--- a/fio_validator.py
+++ b/fio_validator.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import argparse
+import json
+import sys
+
+
+def validate_fio(json_file):
+  try:
+    with open(json_file) as f:
+      data = json.load(f)
+  except Exception as e:
+    print(f"ERROR: Failed to parse FIO JSON output: {e}")
+    return False
+
+  if "jobs" not in data:
+    print("ERROR: No jobs in FIO output")
+    return False
+
+  for job in data["jobs"]:
+    if job.get("error", 0) != 0:
+      print(
+          f"ERROR: Job {job.get('jobname')} failed with error"
+          f" {job.get('error')}"
+      )
+      return False
+
+    read_bytes = job.get("read", {}).get("io_bytes", 0)
+    write_bytes = job.get("write", {}).get("io_bytes", 0)
+    total_bytes = read_bytes + write_bytes
+    if total_bytes == 0:
+      print(f"ERROR: Job {job.get('jobname')} performed 0 IO bytes")
+      return False
+    print(
+        f"Job {job.get('jobname')} passed (read={read_bytes},"
+        f" write={write_bytes} bytes)"
+    )
+  return True
+
+
+def main():
+  parser = argparse.ArgumentParser(description="FIO validator")
+  parser.add_argument(
+      "--json-file", required=True, help="Path to FIO JSON output"
+  )
+  args = parser.parse_args()
+  if not validate_fio(args.json_file):
+    print("Validation failed.")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+  main()

--- a/run_fio_integration_tests.sh
+++ b/run_fio_integration_tests.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+set -euo pipefail
+
+# Parse arguments passed from Bazel
+if [[ $# -lt 6 ]]; then
+  echo "ERROR: Usage: $0 <fio_binary> <ioengine_so> <testbench_helper_sh> <fio_validator_py> <testbench_setup_py> <testbench_run_py>"
+  exit 1
+fi
+
+FIO_BINARY=$1
+IOENGINE_SO=$2
+TESTBENCH_HELPER_SH=$3
+FIO_VALIDATOR_PY=$4
+TESTBENCH_SETUP_PY=$5
+TESTBENCH_RUN_PY=$6
+
+# Source the shared helper
+source "${TESTBENCH_HELPER_SH}"
+
+
+# Helper function to run FIO and validate output
+run_fio_test() {
+  local test_name=$1
+  shift
+  echo "===================================================="
+  echo "Running FIO test: ${test_name}..."
+  echo "===================================================="
+  
+  # Create a bucket for this specific test
+  curl -s -X POST "http://localhost:${HTTP_PORT}/storage/v1/b?project=test-project" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\": \"${test_name}\"}" > /dev/null
+
+  "${FIO_BINARY?}" --name="${test_name?}" "${FIO_COMMON[@]}" "$@" \
+    >"${TEST_TMPDIR}/fio_out.json"
+  
+  # Validate output
+  python3 "${FIO_VALIDATOR_PY}" --json-file "${TEST_TMPDIR}/fio_out.json"
+
+  echo "Test ${test_name} PASSED and cleaned up."
+}
+
+# Callback function called by the testbench helper
+execute_tests() {
+  local HTTP_PORT=$1
+  local GRPC_PORT=$2
+  local FIO_COMMON=(
+    "--ioengine=external:${IOENGINE_SO}"
+    "--thread"
+    "--go-storage-insecure-credentials=1"
+    "--go-storage-endpoint=localhost:${GRPC_PORT}"
+    "--create_serialize=0"
+    "--output-format=json"
+  )
+
+  run_fio_test "single_stream_reads_buffered" \
+    --rw=randread \
+    --bs=8K \
+    --filesize=4M \
+    --numjobs=1 \
+    --nrfiles=1 \
+    --iodepth=1 \
+    --filename=single_stream_reads_buffered/file \
+    --direct=0
+
+  run_fio_test "single_stream_reads_direct" \
+    --rw=randread \
+    --bs=8K \
+    --filesize=4M \
+    --numjobs=1 \
+    --nrfiles=1 \
+    --iodepth=1 \
+    --filename=single_stream_reads_direct/file \
+    --direct=1
+
+  run_fio_test "single_stream_iodepth" \
+    --rw=randread \
+    --bs=8K \
+    --filesize=8M \
+    --numjobs=1 \
+    --nrfiles=1 \
+    --iodepth=8 \
+    --filename=single_stream_iodepth/file
+
+  run_fio_test "multi_job_shared_client" \
+    --rw=randread \
+    --bs=8K \
+    --filesize=8M \
+    --numjobs=4 \
+    --nrfiles=1 \
+    --iodepth=1 \
+    --filename_format='multi_job_shared_client/file.$jobnum' \
+    --go-storage-threads-share-client=1
+
+  run_fio_test "multi_job_unique_clients" \
+    --rw=randread \
+    --bs=8K \
+    --filesize=8M \
+    --numjobs=4 \
+    --nrfiles=1 \
+    --iodepth=1 \
+    --filename_format='multi_job_unique_clients/file.$jobnum' \
+    --go-storage-threads-share-client=0
+
+  run_fio_test "write_buffered" \
+    --rw=write \
+    --bs=4K \
+    --filesize=8M \
+    --numjobs=1 \
+    --iodepth=1 \
+    --filename=write_buffered/file \
+    --direct=0
+
+  run_fio_test "write_direct" \
+    --rw=write \
+    --bs=4K \
+    --filesize=8M \
+    --numjobs=1 \
+    --iodepth=1 \
+    --filename=write_direct/file \
+    --direct=1
+
+  run_fio_test "multi_write" \
+    --rw=write \
+    --bs=4K \
+    --filesize=2M \
+    --numjobs=4 \
+    --iodepth=1 \
+    --filename_format='multi_write/file.$jobnum'
+
+  run_fio_test "single_job_multi_write" \
+    --rw=write \
+    --bs=4K \
+    --filesize=2M \
+    --numjobs=1 \
+    --nrfiles=4 \
+    --iodepth=1 \
+    --filename_format='single_job_multi_write/file.$filenum'
+
+  run_fio_test "large_reads" \
+    --rw=randread \
+    --bs=1M \
+    --filesize=4M \
+    --numjobs=3 \
+    --nrfiles=1 \
+    --iodepth=2 \
+    --filename_format='large_reads/file.$jobnum'
+
+  echo "All FIO integration tests completed successfully!"
+}
+
+# Run the testbench and execute our tests
+run_with_testbench "${TESTBENCH_SETUP_PY}" "${TESTBENCH_RUN_PY}" execute_tests

--- a/run_fio_integration_tests.sh
+++ b/run_fio_integration_tests.sh
@@ -13,16 +13,15 @@ if [[ $# -lt 6 ]]; then
   exit 1
 fi
 
-FIO_BINARY=$1
-IOENGINE_SO=$2
-TESTBENCH_HELPER_SH=$3
-FIO_VALIDATOR_PY=$4
-TESTBENCH_SETUP_PY=$5
-TESTBENCH_RUN_PY=$6
+FIO_BINARY="$1"
+IOENGINE_SO="$2"
+TESTBENCH_HELPER_SH="$3"
+FIO_VALIDATOR_PY="$4"
+TESTBENCH_SETUP_PY="$5"
+TESTBENCH_RUN_PY="$6"
 
-# Source the shared helper
-source "${TESTBENCH_HELPER_SH}"
-
+# shellcheck disable=SC1090
+source "${TESTBENCH_HELPER_SH?}"
 
 # Helper function to run FIO and validate output
 run_fio_test() {
@@ -38,10 +37,10 @@ run_fio_test() {
     -d "{\"name\": \"${test_name}\"}" > /dev/null
 
   "${FIO_BINARY?}" --name="${test_name?}" "${FIO_COMMON[@]}" "$@" \
-    >"${TEST_TMPDIR}/fio_out.json"
+    >"${TEST_TMPDIR?}/fio_out.json"
   
   # Validate output
-  python3 "${FIO_VALIDATOR_PY}" --json-file "${TEST_TMPDIR}/fio_out.json"
+  python3 "${FIO_VALIDATOR_PY}" --json-file "${TEST_TMPDIR?}/fio_out.json"
 
   echo "Test ${test_name} PASSED and cleaned up."
 }

--- a/run_fio_integration_tests.sh
+++ b/run_fio_integration_tests.sh
@@ -4,6 +4,8 @@
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+#
+# shellcheck disable=SC2016
 
 set -euo pipefail
 

--- a/storagewrapper/BUILD.bazel
+++ b/storagewrapper/BUILD.bazel
@@ -1,8 +1,9 @@
 load("@gazelle//:def.bzl", "gazelle")
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 gazelle(name = "gazelle")
 
+# keep
 go_binary(
     name = "storagewrapper",
     embed = [":storagewrapper_lib"],
@@ -23,4 +24,30 @@ go_library(
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//credentials/insecure",
     ],
+)
+
+go_test(
+    name = "storagewrapper_test",
+    srcs = ["storagewrapper_test.go"],
+    embed = [":storagewrapper_lib"],
+    deps = ["@com_google_cloud_go_storage//:storage"],
+)
+
+sh_test(
+    name = "integration_test",
+    srcs = ["run_integration_test.sh"],
+    args = [
+        "$(location :storagewrapper_test)",
+        "$(location //:testbench_helper.sh)",
+        "$(location @storage_testbench//:setup.py)",
+        "$(location @storage_testbench//:testbench_run.py)",
+    ],
+    data = [
+        ":storagewrapper_test",
+        "//:testbench_helper.sh",
+        "@storage_testbench//:all_files",
+        "@storage_testbench//:setup.py",
+        "@storage_testbench//:testbench_run.py",
+    ],
+    tags = ["local"],
 )

--- a/storagewrapper/BUILD.bazel
+++ b/storagewrapper/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 gazelle(name = "gazelle")
 
-# keep
 go_binary(
     name = "storagewrapper",
     embed = [":storagewrapper_lib"],

--- a/storagewrapper/run_integration_test.sh
+++ b/storagewrapper/run_integration_test.sh
@@ -13,13 +13,13 @@ if [[ $# -lt 4 ]]; then
   exit 1
 fi
 
-TEST_BINARY=$1
-TESTBENCH_HELPER_SH=$2
-TESTBENCH_SETUP_PY=$3
-TESTBENCH_RUN_PY=$4
+TEST_BINARY="$1"
+TESTBENCH_HELPER_SH="$2"
+TESTBENCH_SETUP_PY="$3"
+TESTBENCH_RUN_PY="$4"
 
-# Source the shared helper
-source "${TESTBENCH_HELPER_SH}"
+# shellcheck disable=SC1090
+source "${TESTBENCH_HELPER_SH?}"
 
 # Callback function called by the testbench helper
 execute_go_test() {

--- a/storagewrapper/run_integration_test.sh
+++ b/storagewrapper/run_integration_test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+set -euo pipefail
+
+# Parse arguments passed from Bazel
+if [[ $# -lt 4 ]]; then
+  echo "ERROR: Usage: $0 <test_binary> <testbench_helper_sh> <testbench_setup_py> <testbench_run_py>"
+  exit 1
+fi
+
+TEST_BINARY=$1
+TESTBENCH_HELPER_SH=$2
+TESTBENCH_SETUP_PY=$3
+TESTBENCH_RUN_PY=$4
+
+# Source the shared helper
+source "${TESTBENCH_HELPER_SH}"
+
+# Callback function called by the testbench helper
+execute_go_test() {
+  local http_port=$1
+  local grpc_port=$2
+
+  echo "Running Go integration test..."
+  export STORAGE_EMULATOR_HOST="http://localhost:${http_port}"
+  export STORAGE_EMULATOR_GRPC_ENDPOINT="localhost:${grpc_port}"
+
+  "${TEST_BINARY}" -test.v
+}
+
+# Run the testbench and execute our Go test
+run_with_testbench "${TESTBENCH_SETUP_PY}" "${TESTBENCH_RUN_PY}" execute_go_test
+
+echo "Test completed successfully!"

--- a/storagewrapper/storagewrapper_test.go
+++ b/storagewrapper/storagewrapper_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestWriteThenRead(t *testing.T) {
+	t.Parallel()
+
 	grpcEndpoint := os.Getenv("STORAGE_EMULATOR_GRPC_ENDPOINT")
 	if grpcEndpoint == "" {
 		t.Skip("STORAGE_EMULATOR_GRPC_ENDPOINT not set, skipping integration test")

--- a/storagewrapper/storagewrapper_test.go
+++ b/storagewrapper/storagewrapper_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"unsafe"
+
+	"cloud.google.com/go/storage"
+)
+
+func TestWriteThenRead(t *testing.T) {
+	grpcEndpoint := os.Getenv("STORAGE_EMULATOR_GRPC_ENDPOINT")
+	if grpcEndpoint == "" {
+		t.Skip("STORAGE_EMULATOR_GRPC_ENDPOINT not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("failed to create standard client: %v", err)
+	}
+	defer client.Close()
+
+	bucketName := "integration-read-test-bucket"
+	objectName := "integration-read-test-object"
+	expectedContent := []byte("Verification content for storagewrapper read integration!")
+
+	bucket := client.Bucket(bucketName)
+	if err := bucket.Create(ctx, "test-project", nil); err != nil {
+		t.Fatalf("failed to create bucket: %v", err)
+	}
+
+	td, err := goStorageInit(2, grpcEndpoint, 1, false, true)
+	if err != nil {
+		t.Fatalf("goStorageInit failed: %v", err)
+	}
+
+	filename := fmt.Sprintf("%s/%s", bucketName, objectName)
+	wf, err := goStorageOpenWriteonly(td, false, filename)
+	if err != nil {
+		t.Fatalf("goStorageOpenWriteonly failed: %v", err)
+	}
+	if q := wf.enqueue(expectedContent, 0, unsafe.Pointer(uintptr(0))); q != fioQCompleted {
+		t.Fatalf("write enqueue did not succeed immediately: %v", q)
+	}
+	if err := wf.Close(); err != nil {
+		t.Fatalf("write close failed: %v", err)
+	}
+
+	rf, err := goStorageOpenReadonly(td, false, filename)
+	if err != nil {
+		t.Fatalf("goStorageOpenReadonly failed: %v", err)
+	}
+	defer rf.Close()
+
+	buf := make([]byte, len(expectedContent))
+	tag := unsafe.Pointer(uintptr(42))
+	if q := rf.enqueue(buf, 0, tag); q != 1 {
+		t.Fatalf("read enqueue did not queue: %v", q)
+	}
+
+	reaped := goStorageAwaitCompletions(td, 1, 1)
+	if reaped != 1 {
+		t.Fatalf("goStorageAwaitCompletions failed, expected 1, got %d", reaped)
+	}
+
+	reapedTag, ok := goStorageGetEvent(td)
+	if !ok {
+		t.Fatalf("goStorageGetEvent reported error")
+	}
+	if reapedTag != tag {
+		t.Fatalf("goStorageGetEvent returned wrong tag, expected %v, got %v", tag, reapedTag)
+	}
+
+	if string(buf) != string(expectedContent) {
+		t.Fatalf("Content mismatch! expected %q, got %q", expectedContent, buf)
+	}
+}

--- a/testbench_helper.sh
+++ b/testbench_helper.sh
@@ -1,0 +1,97 @@
+# Shared helper for starting and stopping storage-testbench.
+# Source this script and call `run_with_testbench`.
+
+# Function to run storage-testbench and execute a callback.
+# Usage: run_with_testbench <testbench_setup_py> <testbench_run_py> <callback_fn>
+#
+# The callback_fn will be invoked with the following arguments:
+#   callback_fn <http_port> <grpc_port>
+#
+# Parameters:
+#   - http_port: The port the storage-testbench HTTP/REST emulator server is running on.
+#   - grpc_port: The port the storage-testbench gRPC emulator server is running on.
+run_with_testbench() {
+  local testbench_setup_py=$1
+  local testbench_run_py=$2
+  local callback=$3
+
+  local testbench_dir
+  testbench_dir=$(dirname "${testbench_setup_py}")
+  echo "Found storage-testbench in: ${testbench_dir}"
+  echo "Testbench run script: ${testbench_run_py}"
+
+  # Setup virtualenv in TEST_TMPDIR
+  local venv_dir="${TEST_TMPDIR}/venv"
+  echo "Creating virtualenv in ${venv_dir}..."
+  python3 -m venv "${venv_dir}"
+  source "${venv_dir}/bin/activate"
+
+  echo "Installing storage-testbench dependencies..."
+  pip install --quiet --prefer-binary --index-url https://pypi.org/simple "${testbench_dir}"
+
+  # Start the testbench in the background
+  # Deterministically allocate ports based on Bazel TEST_TARGET to avoid parallel conflicts
+  local target="${TEST_TARGET:-//manual/test_$$}"
+  local hash
+  hash=$(echo -n "${target}" | sha256sum | cut -c1-8)
+  local val=$(( 16#$hash ))
+  local http_port=$(( 20000 + (val % 20000) * 2 ))
+  local grpc_port=$(( http_port + 1 ))
+
+  echo "Starting storage-testbench on HTTP port ${http_port} and gRPC port ${grpc_port} (Target: ${target})..."
+
+  if [[ ! -f "${testbench_run_py}" ]]; then
+    echo "ERROR: testbench_run.py not found at ${testbench_run_py}"
+    exit 1
+  fi
+
+  # Run in background. We bind to localhost to be safe.
+  python3 "${testbench_run_py}" localhost ${http_port} 1 > "${TEST_TMPDIR}/testbench.log" 2>&1 &
+  TESTBENCH_PID=$!
+
+  # Ensure cleanup on exit
+  cleanup() {
+    if [[ -n "${TESTBENCH_PID:-}" ]]; then
+      echo "Tearing down storage-testbench (PID ${TESTBENCH_PID})...."
+      kill "${TESTBENCH_PID}" 2>/dev/null || true
+      wait "${TESTBENCH_PID}" 2>/dev/null || true
+    fi
+    if [[ -f "${TEST_TMPDIR}/testbench.log" ]]; then
+      echo "--- testbench.log ---"
+      cat "${TEST_TMPDIR}/testbench.log"
+      echo "---------------------"
+    fi
+  }
+  # Note: The caller should define their own traps if they want,
+  # but this trap will ensure cleanup when the bash process exits.
+  trap cleanup EXIT
+
+  # Wait for HTTP server to be ready
+  echo "Waiting for storage-testbench HTTP server to be ready..."
+  local ready=0
+  for i in {1..30}; do
+    if curl -s -o /dev/null http://localhost:${http_port}/; then
+      echo "storage-testbench HTTP server is ready!"
+      ready=1
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ ${ready} -ne 1 ]]; then
+    echo "ERROR: storage-testbench HTTP server failed to start"
+    exit 1
+  fi
+
+  # Start gRPC server
+  echo "Starting gRPC server on port ${grpc_port}..."
+  local grpc_status
+  grpc_status=$(curl -s "http://localhost:${http_port}/start_grpc?port=${grpc_port}")
+  echo "gRPC status: ${grpc_status}"
+
+  # Wait a bit for gRPC server to start
+  sleep 2
+
+  # Invoke caller's callback with ports
+  "${callback}" "${http_port}" "${grpc_port}"
+}

--- a/testbench_helper.sh
+++ b/testbench_helper.sh
@@ -1,3 +1,9 @@
+# Copyright 2026 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
 # Shared helper for starting and stopping storage-testbench.
 # Source this script and call `run_with_testbench`.
 


### PR DESCRIPTION
Add integration tests for the ioengine. This way as we make changes, we can automate running fio to confirm that things continue to behave as expected.

We depend on the storage_testbench. To avoid polluting build times too much, we depend on users to have python3 installed. That is a relatively safe assumption, but we document it in the README regardless. We trade off some of the hermeticity of bazel for the convenience of a comparatively faster build.