### PR TITLE
fix: Relicense as MIT.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 Google LLC
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 name: 'Build'
 

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 Google LLC
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 name: 'License'
 
@@ -27,4 +27,4 @@ jobs:
           cache: true
 
       - name: 'Check'
-        run: 'go run github.com/google/addlicense@v1.1.1 -check -s=only .'
+        run: 'go run github.com/google/addlicense@v1.1.1 -check -l mit -s=only .'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,5 @@
 # Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: MIT
 
 name: 'lint'
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,5 +1,5 @@
 # Copyright 2025 Google LLC
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 # This workflow uses actions that are not certified by GitHub. They are provided
 # by a third-party and are governed by separate terms of service, privacy


### PR DESCRIPTION
It's simpler and less error-prone to license the whole repo under MIT, instead of having some parts licensed Apache-2.0.